### PR TITLE
feat: lastEventResolver

### DIFF
--- a/src/server-extension/model/event.model.ts
+++ b/src/server-extension/model/event.model.ts
@@ -1,0 +1,32 @@
+import { Field, ObjectType } from 'type-graphql';
+
+@ObjectType()
+export class LastEventEntity {
+  @Field(() => String, { nullable: false })
+  id!: string;
+
+  @Field(() => String, { nullable: false })
+  name!: string;
+
+  @Field(() => String, { nullable: false })
+  issuer!: string;
+
+  @Field(() => Date, { nullable: false })
+  timestamp!: Date;
+
+  @Field(() => String, { nullable: false })
+  metadata!: string;
+
+  @Field(() => String, { nullable: false })
+  value!: string;
+
+  @Field(() => String, { nullable: false, name: 'currentOwner' })
+  current_owner!: string;
+
+  @Field(() => String, { nullable: true })
+  image!: string;
+
+  constructor(props: Partial<LastEventEntity>) {
+    Object.assign(this, props);
+  }
+}

--- a/src/server-extension/query/event.ts
+++ b/src/server-extension/query/event.ts
@@ -6,7 +6,7 @@ export const lastEventQuery = `SELECT
     e.current_owner,
     me.image as image,
     MAX(e.timestamp) as timestamp,
-    MAX(e.meta::bigint) as value
+    MAX(e.meta) as value
 
 FROM event e
     JOIN nft_entity ne on e.nft_id = ne.id

--- a/src/server-extension/query/event.ts
+++ b/src/server-extension/query/event.ts
@@ -1,0 +1,19 @@
+export const lastEventQuery = `SELECT
+    DISTINCT ne.id as id,
+    ne.name as name,
+    ne.issuer as issuer,
+    ne.metadata as metadata,
+    e.current_owner,
+    me.image as image,
+    MAX(e.timestamp) as timestamp,
+    MAX(e.meta::bigint) as value
+
+FROM event e
+    JOIN nft_entity ne on e.nft_id = ne.id
+    LEFT join metadata_entity me on me.id = ne.metadata
+WHERE
+    e.interaction = $1
+    AND ne.burned = false
+GROUP BY ne.id, me.id, e.current_owner, me.image
+ORDER BY MAX(e.timestamp) DESC
+LIMIT $2 OFFSET $3`;

--- a/src/server-extension/resolvers/event.ts
+++ b/src/server-extension/resolvers/event.ts
@@ -1,0 +1,22 @@
+import { Arg, Query, Resolver } from 'type-graphql';
+import type { EntityManager } from 'typeorm';
+import { NFTEntity } from '../../model/generated';
+import { LastEventEntity } from '../model/event.model';
+import { lastEventQuery } from '../query/event';
+import { makeQuery } from '../utils';
+import { Interaction } from '../../model';
+
+@Resolver()
+export class EventResolver {
+  constructor(private tx: () => Promise<EntityManager>) {}
+
+  @Query(() => [LastEventEntity])
+  async lastEvent(
+    @Arg('interaction', { nullable: true, defaultValue: Interaction.LIST }) interaction: Interaction,
+      @Arg('limit', { nullable: true, defaultValue: 20 }) limit: number,
+      @Arg('offset', { nullable: true, defaultValue: 0 }) offset: number,
+  ): Promise<[LastEventEntity]> {
+    const result: [LastEventEntity] = await makeQuery(this.tx, NFTEntity, lastEventQuery, [interaction, limit, offset]);
+    return result;
+  }
+}

--- a/src/server-extension/resolvers/index.ts
+++ b/src/server-extension/resolvers/index.ts
@@ -1,4 +1,5 @@
 import { WalletResolver } from './walletResolver';
 import { OfferStatsResolver } from './offerStatsResolver';
+import { EventResolver } from './event';
 
-export { WalletResolver, OfferStatsResolver };
+export { WalletResolver, OfferStatsResolver, EventResolver };


### PR DESCRIPTION
This is for [#3570](https://github.com/kodadot/nft-gallery/issues/3570) and [#3571](https://github.com/kodadot/nft-gallery/issues/3571), query latest event with condition `interaction`.
The same implement as rmrk, only logic about `passionList` remove.

