### PR TITLE
🔧 ROCOCO env url

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,5 @@
 DB_NAME=squid
 DB_PORT=23798
 GQL_PORT=4350
-ARCHIVE_URL=https://basilisk-firesquid.play.hydration.cloud/graphql
-NODE_URL=wss://rpc.basilisk.cloud
+ARCHIVE_URL=https://basilisk-rococo-firesquid.play.hydration.cloud/graphql
+NODE_URL=wss://rococo-basilisk-rpc.hydration.dev


### PR DESCRIPTION
BSX is still in progress, revert env var to use rococo
What about production?

### PR type

- [x] Bugfix

I had to recreate db migration to make processor running, here's the commands I've run:

```bash
make down 
rm -rf db/migrations/*.js
make up
npx squid-typeorm-migration generate
make process
```

![Capture d’écran 2022-09-27 à 4 41 26 PM](https://user-images.githubusercontent.com/9987732/192557868-dd12972e-adca-438d-9063-ab6edc09327d.png)

```postgre
squid=# SELECT * FROM series;
 id | unique | unique_collectors | sold | total | average_price | floor_price | buys | volume | name | metadata | image
----+--------+-------------------+------+-------+---------------+-------------+------+--------+------+----------+-------
(0 rows)

```

running query in docker cli:
```postgre
     id     |          name           |                      issuer                       |                                metadata                                 |
                     image                                  | unique | unique_collectors | sold | total |     average_price      |  floor_price  | highest_sale  |    volume     |
 buys
------------+-------------------------+---------------------------------------------------+-------------------------------------------------------------------------+-------------
------------------------------------------------------------+--------+-------------------+------+-------+------------------------+---------------+---------------+---------------+
------
 1559871636 | Your obvious collection | bXgvP2cQzEnPvuPQHRghz9dUYovqzyPhXBRXbNwVCef7nsmqb | ipfs://ipfs/bafkreiefw5c3wg5q26zfzzlltz6s2mcrqdb2vdcavpzmiak4cdhonopquq | ipfs://ipfs/
bafkreiaute7id4shzhqxe3kwwkf6ixzfkwldrp7vfy4b7uboy5i3sptuqa |      1 |                 1 |    1 |     1 |     5000000000000.0000 | 5000000000000 |   95000000000 |   95000000000 |
    1
 2773267381 | Windows                 | bXkQe5T8pdkGn78sS6viEUs18wf1kAubDTQX1WWaEdMqDNyCN | ipfs://ipfs/bafkreic3voawdjrbu6c36jqu3niz3jou7uyb7ambyu5x66jfmoj5o647wq | ipfs://ipfs/
bafybeidjzbdnezgvxziwfminiurocml7l23sewd7khjdw447ztkkcyjh2e |      1 |                 1 |    1 |     1 | 0.00000000000000000000 |               |   10000000000 |   10000000000 |
    1
 3033790537 | O'rly                   | bXjmyHufR6HcjAtKNVTV4UjHj3poQW3d2yYWKDdWe5cGGmg3z | ipfs://ipfs/bafkreicxyo2afhxssxipca26ooxkgsecr7l57zoqjnlo2722mogaf2bkkq | ipfs://ipfs/
bafkreicov4jjkhp5zpqqy4secdgeljk5i3mv37akevoqgkjuxalwu2piwu |      1 |                 1 |    1 |     1 | 0.00000000000000000000 |               | 1000000000000 | 1000000000000 |
    1
 3132385849 | Plišasta igrača         | bXkmyHuV41u7yVDsYEGerdtZZzkA8szX7RYtkkxWcd6J5CSGP | ipfs://ipfs/bafkreidh5mncgilu5khxlm3qi7rhizxamiylxfjbyub6t22cqo2gsnthby | ipfs://ipfs/
bafkreid7bve3cayhtik7edsmqul4lnkva67bdw467zhj3ovybkx34pwlly |      2 |                 2 |    2 |     3 | 0.00000000000000000000 |               |  150000000000 |  260000000000 |
    3
 3424749042 | seduction               | bXjMVEdCzhjYbPc5rJk7NvPSDRiiNuCT3GdqohFp3wdpzJL6Z | ipfs://ipfs/bafkreifd4feiiqxdl6p5mlfsfsdt3of4rjnzzitvdvewb4kyf5m65rodhy | ipfs://ipfs/
bafybeic2l44slh5votf2elcomovxkx43hzn72w7xsq45qxlqm3axf5fu5a |      1 |                 1 |    1 |     1 | 0.00000000000000000000 |               | 1000000000000 | 1000000000000 |
    1
 659233203  | test123                 | bXkJuVse1JQXeCC7ooaGUqWKPgHGStuK5qNzZmmeVea2YDn84 | ipfs://ipfs/bafkreidy2pvsjl2kq63gztasohtcze5a56zuxmd534nnqxl2yonqypo5ea | ipfs://ipfs/
bafkreiffp54j5s2itgok6vmvmcoixu6z2birdx5xgrzlrgrag24zvdozdi |      1 |                 1 |    1 |     1 | 0.00000000000000000000 |               |   10000000000 |   10000000000 |
    1
 914494658  | Fancy cats              | bXkaQPkcaNytoF6rAg5nbmrMy5wWGZrykUMGD39yqxvzivRTr | ipfs://ipfs/bafkreidfxbehe3eu3tw6cthlml7fosafwcuo3mhqldlspntay2hmco6ksm | ipfs://ipfs/
bafybeigtu33g74uhxggx3pz4nf76as5e6frmb6tobsb5kol573x7e7agvu |      1 |                 1 |    1 |     1 |     5000000000000.0000 | 5000000000000 |  500000000000 |  500000000000 |
    1
(7 rows)
```