### PR TITLE
🔧 series floorprice

### DIFF
--- a/src/mappings/utils/cache.ts
+++ b/src/mappings/utils/cache.ts
@@ -19,9 +19,9 @@ enum Query {
       COUNT(distinct ne.current_owner)   as unique_collectors,
       COUNT(distinct ne.current_owner)   as sold,
       COUNT(ne.*)                        as total,
-      AVG(ne.price)                      as average_price,
-      MIN(NULLIF(ne.price, 0))           as floor_price,
-      COALESCE(MAX(e.meta :: bigint), 0) as highest_sale,
+      AVG(e.meta::bigint)                      as average_price,
+      MIN(NULLIF(e.meta::bigint, 0))           as floor_price,
+      COALESCE(MAX(e.meta::bigint), 0) as highest_sale,
       COALESCE(SUM(e.meta::bigint), 0)   as volume,
       COUNT(e.*)                         as buys,
       0                                  as emote_count

--- a/src/server-extension/resolvers/series.ts
+++ b/src/server-extension/resolvers/series.ts
@@ -54,8 +54,8 @@ export class SeriesResolver {
         COUNT(distinct ne.current_owner) as unique_collectors, 
         COUNT(distinct ne.current_owner) as sold, 
         COUNT(ne.*) as total, 
-        AVG(ne.price) as average_price, 
-        MIN(NULLIF(ne.price, 0)) as floor_price, 
+        AVG(e.meta::bigint) as average_price, 
+        MIN(NULLIF(e.meta::bigint, 0)) as floor_price, 
         COALESCE(MAX(e.meta::bigint), 0) as highest_sale,
         COALESCE(SUM(e.meta::bigint), 0) as volume, 
         COUNT(e.*) as buys 


### PR DESCRIPTION
on series:
- SQL query `floor_price` will always be null since it's based on `nft.price` from ` e.interaction = 'BUY'`
- on `handleTokenBuy` price is set to `BigInt(0)`

```gql
query MyQuery {
  events(where: {interaction_eq: BUY}, limit: 5) {
    interaction
    meta
    timestamp
    caller
    nft {
      price
    }
  }
  series(limit: 5) {
    emoteCount
    floorPrice
    highestSale
  }
}
```

### PR type

- [x] Bugfix

### What's new?

- [x] PR closes/related #96 
- [x] This PR is required for kodadot/nft-gallery series resolver

### Before submitting Pull Request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [ ] I've didn't break any original functionality
- [x] I've posted a screenshot of demonstrated change in this PR

### Optional

- [x] I've run the indexer and it hasn't failed

### Screenshot

![Capture d’écran 2022-11-02 à 3 05 49 PM](https://user-images.githubusercontent.com/9987732/199510255-5902b7fe-0a8a-4df9-a762-a872962a3904.png)

